### PR TITLE
Tiny fixes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ impl Program {
                 next.big_step(state);
             }
             Loop(ref body_and_next) => {
-                let &(ref body, ref next) = body_and_next.as_ref();
+                let (ref body, ref next) = **body_and_next;
                 if state.get_current_bit() {
                     body.big_step(state);
                     self.big_step(state);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ extern crate bit_vec;
 extern crate type_operators;
 
 
-use std::collections::HashMap;
-
 use bit_vec::BitVec;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ impl Program {
 
     // Convenience function to run a program without having to write out the
     // state allocation boilerplate.
-    fn run(&self) -> State {
+    pub fn run(&self) -> State {
         let mut state: State = State {
             ptr: 0,
             bits: [0; (std::u16::MAX as usize + 1) / 8],


### PR DESCRIPTION
Hi, great blog post. I mainly wanted to fix the use of .as_ref() and express it using just `**`. It's really unfortunate that conversion traits like AsRef have a use in freestanding (non-generic) code like this, it's not intentional.

Making `run` public makes sure everything that should be used for running a program is counted as used.